### PR TITLE
Added Test Mode, Fixed unauthorized ugly error

### DIFF
--- a/upload/admin/controller/payment/bitpay.php
+++ b/upload/admin/controller/payment/bitpay.php
@@ -96,6 +96,7 @@ class ControllerPaymentBitpay extends Controller
         $this->data['entry_confirmed_status']  = $this->language->get('entry_confirmed_status');
         $this->data['entry_invalid_status']    = $this->language->get('entry_invalid_status');
         $this->data['entry_transaction_speed'] = $this->language->get('entry_transaction_speed');
+        $this->data['entry_test_mode']         = $this->language->get('entry_test_mode');
         $this->data['entry_status']            = $this->language->get('entry_status');
         $this->data['entry_sort_order']        = $this->language->get('entry_sort_order');
         $this->data['button_save']             = $this->language->get('button_save');
@@ -170,6 +171,15 @@ class ControllerPaymentBitpay extends Controller
         else
         {
             $this->data[$this->payment_module_name.'_transaction_speed'] = $this->config->get($this->payment_module_name.'_transaction_speed'); 
+        } 
+
+        if (isset($this->request->post[$this->payment_module_name.'_test_mode']))
+        {
+            $this->data[$this->payment_module_name.'_test_mode'] = $this->request->post[$this->payment_module_name.'_test_mode'];
+        }
+        else
+        {
+            $this->data[$this->payment_module_name.'_test_mode'] = $this->config->get($this->payment_module_name.'_test_mode'); 
         } 
 
         if (isset($this->request->post[$this->payment_module_name.'_status']))

--- a/upload/admin/language/english/payment/bitpay.php
+++ b/upload/admin/language/english/payment/bitpay.php
@@ -38,6 +38,7 @@ $_['entry_api_key']           = 'API Key:';
 $_['entry_confirmed_status']  = 'Confirmed Status:';
 $_['entry_invalid_status']    = 'Invalid Status:';
 $_['entry_transaction_speed'] = 'Transaction Speed:';
+$_['entry_test_mode']		  = 'Test Mode:';
 $_['entry_status']            = 'Status:';
 $_['entry_sort_order']        = 'Sort Order:';
 

--- a/upload/admin/view/template/payment/bitpay.tpl
+++ b/upload/admin/view/template/payment/bitpay.tpl
@@ -95,6 +95,18 @@
                 <?php } ?>
               </select></td>
           </tr>
+          <tr>
+            <td><?php echo $entry_test_mode; ?></td>
+            <td><select name="bitpay_test_mode"> 
+                <?php if ($bitpay_test_mode) { ?>
+                <option value="1" selected="selected"><?php echo $text_enabled; ?></option>
+                <option value="0"><?php echo $text_disabled; ?></option>
+                <?php } else { ?>
+                <option value="1"><?php echo $text_enabled; ?></option>
+                <option value="0" selected="selected"><?php echo $text_disabled; ?></option>
+                <?php } ?>
+              </select></td>
+          </tr>
         <tr>
           <td><?php echo $entry_status; ?></td>
           <td><select name="bitpay_status"> 

--- a/upload/bitpay/bp_lib.php
+++ b/upload/bitpay/bp_lib.php
@@ -135,7 +135,7 @@ function bpCreateInvoice($orderId, $price, $posData, $options = array())
         }
     }
 	$post     = json_encode($post);
-	$response = bpCurl('https://bitpay.com/api/invoice/', $options['apiKey'], $post);
+	$response = bpCurl('https://'.($options['testMode'] ? 'test.' : '').'bitpay.com/api/invoice/', $options['apiKey'], $post);
 
 	return $response;
 }
@@ -199,7 +199,7 @@ function bpGetInvoice($invoiceId, $apiKey=false)
 		$apiKey = $bpOptions['apiKey'];		
     }
 
-	$response = bpCurl('https://bitpay.com/api/invoice/'.$invoiceId, $apiKey);
+	$response = bpCurl('https://'.($options['testMode'] ? 'test.' : '').'bitpay.com/api/invoice/'.$invoiceId, $apiKey);
 	if (is_string($response))
     {
 		return $response; // error

--- a/upload/bitpay/bp_options.php
+++ b/upload/bitpay/bp_options.php
@@ -67,4 +67,7 @@ $bpOptions['fullNotifications'] = 'true';
 // transaction speed: low/medium/high.   See API docs for more details.
 $bpOptions['transactionSpeed'] = 'low'; 
 
+// If set to true, then the test.bitpay/api is used
+$bpOptions['testMode'] = false; 
+
 ?>

--- a/upload/catalog/controller/payment/bitpay.php
+++ b/upload/catalog/controller/payment/bitpay.php
@@ -81,14 +81,15 @@ class ControllerPaymentBitpay extends Controller
             'currency'          => $order['currency_code'],
             'physical'          => 'true',
             'fullNotifications' => 'true',
-            'transactionSpeed'  => $this->config->get($this->payment_module_name.'_transaction_speed')
+            'transactionSpeed'  => $this->config->get($this->payment_module_name.'_transaction_speed'),
+            'testMode'          => $this->config->get($this->payment_module_name.'_test_mode')
         );
         $response = bpCreateInvoice($order['order_id'], $price, $posData, $options);
 		
         if(array_key_exists('error', $response))
         {
             $this->log("communication error");
-			$this->log($response['error']);
+			$this->log(var_export($response['error'], true));
             echo "{\"error\": \"Error: Problem communicating with payment provider.\\nPlease try again later.\"}";
         }
         else


### PR DESCRIPTION
Test Mode implements the test.bitpay.com/api, and allows the user to
switch between it and live mode.

If an incorrect API Key is used, PHP errors trying to log a string when
the server response is an array. The array is now converted to a string
first.
